### PR TITLE
Re-add intervals when reconnecting

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -194,6 +194,8 @@ VoltConnection.prototype.onClose = function(had_error) {
       _this.initSocket(new TLSSocket())
       _this.socket.connect(_this.config.port, _this.config.host, function() {
         clearInterval(reconnectTimer);
+        _this.queryTimeoutInterval = setInterval(_this._manageOustandingQueries, _this.config.queryTimeoutInterval);
+        _this.flushInterval = setInterval(_this._flush, _this.config.flushInterval);
       });
     }, _this.config.reconnectInterval);
   }


### PR DESCRIPTION
The flush interval was cleared when the socket was closed but it wasn't
correctly reinitialised when reconnected